### PR TITLE
feat(profile): add scoped-down "client" profile for client laptops

### DIFF
--- a/.chezmoi.toml.tmpl
+++ b/.chezmoi.toml.tmpl
@@ -12,7 +12,7 @@
 {{-   $headless = promptBool "headless" true -}}
 {{- end -}}
 {{- if eq .chezmoi.os "darwin" -}}
-{{-   $profile = promptChoice "profile" (list "work" "personal") -}}
+{{-   $profile = promptChoice "profile" (list "work" "personal" "client") -}}
 {{- end -}}
 {{- $hasAge := and (eq .chezmoi.os "darwin") (eq $profile "personal") -}}
 

--- a/.chezmoi.toml.tmpl
+++ b/.chezmoi.toml.tmpl
@@ -12,7 +12,7 @@
 {{-   $headless = promptBool "headless" true -}}
 {{- end -}}
 {{- if eq .chezmoi.os "darwin" -}}
-{{-   $profile = promptChoice "profile" (list "work" "personal" "client") -}}
+{{-   $profile = promptChoice "profile" (list "work" "personal" "minimal") -}}
 {{- end -}}
 {{- $hasAge := and (eq .chezmoi.os "darwin") (eq $profile "personal") -}}
 

--- a/.chezmoidata/brew.yaml
+++ b/.chezmoidata/brew.yaml
@@ -147,7 +147,7 @@ homebrew:
       - "burp-suite-professional"
       - "postman"
       - "slack"
-  client:
+  minimal:
     taps:
       - "joshmedeski/sesh"        # sesh session manager (has config)
     brews:

--- a/.chezmoidata/brew.yaml
+++ b/.chezmoidata/brew.yaml
@@ -2,7 +2,6 @@ homebrew:
   shared:
     taps:
       - "jackwiseman/brews" # personal brews
-      - "joshmedeski/sesh" # sesh
       - "nikitabobko/tap" # aerospace
     brews:
       # - "colima, restart_service: :changed"
@@ -32,7 +31,6 @@ homebrew:
       - "harlequin"
       - "iperf3"
       - "iproute2mac"
-      - "joshmedeski/sesh/sesh"
       - "jpeg-turbo"
       - "jq"
       - "just"
@@ -68,6 +66,7 @@ homebrew:
       - "ripgrep"
       - "rsync"
       - "rustup"
+      - "sesh"
       - "snappy"
       - "sshpass"
       - "taskwarrior-tui"
@@ -149,7 +148,6 @@ homebrew:
       - "slack"
   minimal:
     taps:
-      - "joshmedeski/sesh"        # sesh session manager (has config)
     brews:
       - "atuin"                   # zsh cached-eval (history)
       - "bat"
@@ -159,10 +157,10 @@ homebrew:
       - "fzf"
       - "git-delta"               # gitconfig sets pager = delta
       - "jq"
-      - "joshmedeski/sesh/sesh"
       - "mise"                    # zsh cached-eval; on-demand runtimes
       - "neovim"
       - "ripgrep"
+      - "sesh"
       - "television"              # `tv` zsh cached-eval + config
       - "tmux"
       - "tpm"

--- a/.chezmoidata/brew.yaml
+++ b/.chezmoidata/brew.yaml
@@ -147,3 +147,25 @@ homebrew:
       - "burp-suite-professional"
       - "postman"
       - "slack"
+  client:
+    taps:
+      - "joshmedeski/sesh"        # sesh session manager (has config)
+    brews:
+      - "atuin"                   # zsh cached-eval (history)
+      - "bat"
+      - "chezmoi"                 # manage these dotfiles
+      - "coreutils"
+      - "fd"
+      - "fzf"
+      - "git-delta"               # gitconfig sets pager = delta
+      - "jq"
+      - "joshmedeski/sesh/sesh"
+      - "mise"                    # zsh cached-eval; on-demand runtimes
+      - "neovim"
+      - "ripgrep"
+      - "television"              # `tv` zsh cached-eval + config
+      - "tmux"
+      - "tpm"
+      - "zoxide"                  # zsh cached-eval (cd)
+    casks:
+      - "kitty"

--- a/.chezmoiignore
+++ b/.chezmoiignore
@@ -9,6 +9,18 @@ README.md
 .ssh/config
 .ssh/config.age
 {{- end -}}
+{{- if eq .profile "client" }}
+.chezmoiscripts/mac/run_once_after_dock.sh
+.chezmoiscripts/mac/run_onchange_after_defaults.sh
+.chezmoiscripts/mac/run_onchange_after_set-file-handlers.sh
+.ssh/config
+.ssh/config.age
+.config/aerospace/**
+.config/karabiner/**
+.config/1Password/**
+.config/task/**
+.config/wallpapers/**
+{{- end -}}
 {{- end -}}
 
 {{- if or (eq .osid "linux-debian") (eq .osid "linux-arch") }}

--- a/.chezmoiignore
+++ b/.chezmoiignore
@@ -9,7 +9,7 @@ README.md
 .ssh/config
 .ssh/config.age
 {{- end -}}
-{{- if eq .profile "client" }}
+{{- if eq .profile "minimal" }}
 .chezmoiscripts/mac/dock.sh
 .chezmoiscripts/mac/defaults.sh
 .chezmoiscripts/mac/set-file-handlers.sh

--- a/.chezmoiignore
+++ b/.chezmoiignore
@@ -2,9 +2,9 @@ README.md
 .DS_Store
 
 {{- if eq .osid "darwin" }}
-.config/sway/*
-.config/waybar/*
-.config/wpaperd/*
+.config/sway
+.config/waybar
+.config/wpaperd
 {{- if eq .profile "work" }}
 .ssh/config
 .ssh/config.age
@@ -19,6 +19,7 @@ README.md
 .config/karabiner/**
 .config/1Password/**
 .config/task/**
+.config/topgrade
 .config/wallpapers/**
 {{- end -}}
 {{- end -}}

--- a/.chezmoiignore
+++ b/.chezmoiignore
@@ -10,9 +10,9 @@ README.md
 .ssh/config.age
 {{- end -}}
 {{- if eq .profile "client" }}
-.chezmoiscripts/mac/run_once_after_dock.sh
-.chezmoiscripts/mac/run_onchange_after_defaults.sh
-.chezmoiscripts/mac/run_onchange_after_set-file-handlers.sh
+.chezmoiscripts/mac/dock.sh
+.chezmoiscripts/mac/defaults.sh
+.chezmoiscripts/mac/set-file-handlers.sh
 .ssh/config
 .ssh/config.age
 .config/aerospace/**

--- a/.chezmoiscripts/mac/run_once_after_install_dependencies.sh
+++ b/.chezmoiscripts/mac/run_once_after_install_dependencies.sh
@@ -2,7 +2,7 @@
 
 # check for existence of homebrew, install if not found
 # this ensures xcode-select is installed as well
-eval "$(/usr/local/bin/brew shellenv)"
+eval "$(/opt/homebrew/bin/brew shellenv)"
 brew bundle install
 
 # if ! command -v brew > /dev/null 2>&1; then

--- a/.chezmoiscripts/mac/run_once_after_install_dependencies.sh
+++ b/.chezmoiscripts/mac/run_once_after_install_dependencies.sh
@@ -2,6 +2,7 @@
 
 # check for existence of homebrew, install if not found
 # this ensures xcode-select is installed as well
+eval "$(/usr/local/bin/brew shellenv)"
 brew bundle install
 
 # if ! command -v brew > /dev/null 2>&1; then

--- a/.chezmoiscripts/mac/run_once_after_install_dependencies.sh
+++ b/.chezmoiscripts/mac/run_once_after_install_dependencies.sh
@@ -1,0 +1,19 @@
+#! /bin/sh
+
+# check for existence of homebrew, install if not found
+# this ensures xcode-select is installed as well
+brew bundle install
+
+# if ! command -v brew > /dev/null 2>&1; then
+#     /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
+#
+#     # the installer doesn't add brew to PATH in the current shell, so load it
+#     # from whichever prefix it landed in before using it
+#     if [ -x /opt/homebrew/bin/brew ]; then
+#         eval "$(/opt/homebrew/bin/brew shellenv)"
+#     elif [ -x /usr/local/bin/brew ]; then
+#         eval "$(/usr/local/bin/brew shellenv)"
+#     fi
+#
+#     brew analytics off
+# fi

--- a/.chezmoiscripts/mac/run_once_before_install_homebrew.sh
+++ b/.chezmoiscripts/mac/run_once_before_install_homebrew.sh
@@ -4,5 +4,14 @@
 # this ensures xcode-select is installed as well
 if ! command -v brew > /dev/null 2>&1; then
     /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
+
+    # the installer doesn't add brew to PATH in the current shell, so load it
+    # from whichever prefix it landed in before using it
+    if [ -x /opt/homebrew/bin/brew ]; then
+        eval "$(/opt/homebrew/bin/brew shellenv)"
+    elif [ -x /usr/local/bin/brew ]; then
+        eval "$(/usr/local/bin/brew shellenv)"
+    fi
+
     brew analytics off
 fi

--- a/Brewfile.tmpl
+++ b/Brewfile.tmpl
@@ -1,3 +1,15 @@
+{{- if eq .profile "client" -}}
+# client (minimal)
+{{- range .homebrew.client.taps }}
+tap "{{ . }}"
+{{- end }}
+{{- range .homebrew.client.brews }}
+brew "{{ . }}"
+{{- end }}
+{{- range .homebrew.client.casks }}
+cask "{{ . }}"
+{{- end }}
+{{- else -}}
 # shared taps
 {{- range .homebrew.shared.taps }}
 tap "{{ . }}"
@@ -46,3 +58,4 @@ cask "{{ . }}"
 cask "{{ . }}"
 {{- end }}
 {{- end }}
+{{- end -}}

--- a/Brewfile.tmpl
+++ b/Brewfile.tmpl
@@ -1,12 +1,12 @@
-{{- if eq .profile "client" -}}
-# client (minimal)
-{{- range .homebrew.client.taps }}
+{{- if eq .profile "minimal" -}}
+# minimal
+{{- range .homebrew.minimal.taps }}
 tap "{{ . }}"
 {{- end }}
-{{- range .homebrew.client.brews }}
+{{- range .homebrew.minimal.brews }}
 brew "{{ . }}"
 {{- end }}
-{{- range .homebrew.client.casks }}
+{{- range .homebrew.minimal.casks }}
 cask "{{ . }}"
 {{- end }}
 {{- else -}}

--- a/dot_gitconfig.tmpl
+++ b/dot_gitconfig.tmpl
@@ -21,11 +21,10 @@
 [credential "https://git.wiseman.sh"]
     helper = 1password
 {{- end }}
-{{- if eq .osid "darwin" }}
+{{- if and (eq .osid "darwin") (ne .profile "client") }}
 [url "git@github.com:"]
     insteadOf = https://github.com
 {{- end }}
-{{- if and (eq .osid "darwin") (ne .profile "client") }}
 [gpg]
   format = ssh
 [gpg "ssh"]

--- a/dot_gitconfig.tmpl
+++ b/dot_gitconfig.tmpl
@@ -21,7 +21,7 @@
 [credential "https://git.wiseman.sh"]
     helper = 1password
 {{- end }}
-{{- if and (eq .osid "darwin") (ne .profile "client") }}
+{{- if and (eq .osid "darwin") (ne .profile "minimal") }}
 [url "git@github.com:"]
     insteadOf = https://github.com
 {{- end }}

--- a/dot_gitconfig.tmpl
+++ b/dot_gitconfig.tmpl
@@ -24,6 +24,8 @@
 {{- if eq .osid "darwin" }}
 [url "git@github.com:"]
     insteadOf = https://github.com
+{{- end }}
+{{- if and (eq .osid "darwin") (ne .profile "client") }}
 [gpg]
   format = ssh
 [gpg "ssh"]

--- a/dot_gitconfig.tmpl
+++ b/dot_gitconfig.tmpl
@@ -25,6 +25,7 @@
 [url "git@github.com:"]
     insteadOf = https://github.com
 {{- end }}
+{{- if and (eq .osid "darwin") (ne .profile "minimal") }}
 [gpg]
   format = ssh
 [gpg "ssh"]

--- a/dot_zshenv.tmpl
+++ b/dot_zshenv.tmpl
@@ -26,8 +26,10 @@ _sdk_cache="${XDG_DATA_HOME:-$HOME/.local/share}/zsh/sdk-path"
 export CPPFLAGS="-I$(<"$_sdk_cache")/usr/include"
 unset _sdk_cache
 
+{{ if ne .profile "client" -}}
 # use 1password for ssh
 export SSH_AUTH_SOCK=~/Library/Group\ Containers/2BUA8C4S2C.com.1password/t/agent.sock
+{{- end }}
 {{- end }}
 
 {{ if and (eq .chezmoi.os "linux") (not .headless) }}

--- a/dot_zshenv.tmpl
+++ b/dot_zshenv.tmpl
@@ -26,7 +26,7 @@ _sdk_cache="${XDG_DATA_HOME:-$HOME/.local/share}/zsh/sdk-path"
 export CPPFLAGS="-I$(<"$_sdk_cache")/usr/include"
 unset _sdk_cache
 
-{{ if ne .profile "client" -}}
+{{ if ne .profile "minimal" -}}
 # use 1password for ssh
 export SSH_AUTH_SOCK=~/Library/Group\ Containers/2BUA8C4S2C.com.1password/t/agent.sock
 {{- end }}


### PR DESCRIPTION
Adds a third macOS profile alongside work/personal that installs only the essential CLI toolchain plus kitty, and skips all system customization.

- .chezmoi.toml.tmpl: add "client" to the profile prompt (stays no-age)
- brew.yaml/Brewfile.tmpl: minimal client set, short-circuits the shared set
- .chezmoiignore: skip dock/defaults/file-handler scripts + app-less configs
- dot_gitconfig.tmpl: disable 1Password commit signing on client
- dot_zshenv.tmpl: don't point SSH_AUTH_SOCK at 1Password on client